### PR TITLE
Add engines field to package.json to document supported nodes

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,9 @@
     "url": "https://github.com/sveltejs/svelte-cli/issues"
   },
   "homepage": "https://github.com/sveltejs/svelte-cli#readme",
+  "engines": {
+    "node": ">=6.0.0"
+  },
   "devDependencies": {
     "chalk": "^1.1.3",
     "eslint": "^3.11.0",


### PR DESCRIPTION
Addresses #4.  Now, when users on older, unsupported nodes will get a warning that looks something like:

```
npm WARN engine svelte-cli@1.0.2: wanted: {"node":">=6.0.0"} (current: {
"node":"4.2.1","npm":"2.14.7"})
```